### PR TITLE
Add of Outlook Calendar integration

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -62,5 +62,9 @@
 	{
 	    "packageId": "WindowSill.SimpleCalculator",
 	    "category": "Utilities"
+	},
+	{
+	    "packageId": "WindowSill.ScreenRecorder",
+	    "category": "Utilities"
 	}
 ]

--- a/extensions.json
+++ b/extensions.json
@@ -62,5 +62,9 @@
 	{
 	    "packageId": "WindowSill.ScreenRecorder",
 	    "category": "Utilities"
+	},
+	{
+	    "packageId": "WindowSill.OutlookCalendar",
+	    "category": "Integration"
 	}
 ]


### PR DESCRIPTION
## Publishing a new extension

A new dynamic extension of an outlook calender integration where the user gets the a single sill view when a meeting is approaching in 30 minutes with ability to expand the view with a sillpopup to see the next upcoming appointments with name and timing, will be expanded more in future with settings where user can set the time, reminders and other stuffs related to it.

## Quality check

Before creating this PR:

- [X] Did you follow the instructions described in [README.md](https://github.com/WindowSill-app/WindowSill-Extensions-Pkgs?tab=readme-ov-file#how-to-publish-a-new-extension-for-windowsill)
- [X] Does your extension has any dependency other than `WindowSill.API`?
  - [X] Did you verify all the dlls and other resources of these dependencies are packed with your NuGet package?
- [X] Did you try installing your extension manually? (generate `nupkg`, rename it to `.wsext`, install it, and test it)
- [X] Did you test your extension in various themes?
   - [X] Dark
   - [X] Light
- [X] Did you test your extension when WindowSill is in various location and size?
    - [X] Left / Right of the screen
        - [X] Large size
        - [X] Medium size
        - [X] Small size
    - [X] Bottom / Top of the screen
        - [X] Large size
        - [X] Medium size
        - [X] Small size

### Screenshots

<img width="376" height="35" alt="image" src="https://github.com/user-attachments/assets/6a13157c-deb9-4600-adba-75759d1b2d33" />

<img width="368" height="168" alt="image" src="https://github.com/user-attachments/assets/c61ab356-d929-4c21-9b41-b595b58f3509" />