### PR TITLE
Added WindowSill.VideoHelper extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -48,6 +48,10 @@
 		"category": "Integration"
 	},
 	{
+		"packageId": "WindowSill.VideoHelper",
+		"category": "Media"
+	},
+	{
 		"packageId": "WindowSill.WebBrowser",
 		"category": "Integration"
 	},


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Publishing a new extension


      Drag &amp; drop videos into WindowSill for instant processing — single files or entire batches.

      • Convert between MP4, AVI, MOV &amp; more
      • Compress to reduce file size

      All the essential video tools you need, right in your digital window sill.

## Quality check

Before creating this PR:

- [X] Did you follow the instructions described in [README.md](https://github.com/WindowSill-app/WindowSill-Extensions-Pkgs?tab=readme-ov-file#how-to-publish-a-new-extension-for-windowsill)
- [X] Does your extension has any dependency other than `WindowSill.API`?
  - [X] Did you verify all the dlls and other resources of these dependencies are packed with your NuGet package?
- [X] Did you try installing your extension manually? (generate `nupkg`, rename it to `.wsext`, install it, and test it)
- [X] Did you test your extension in various themes?
   - [X] Dark
   - [X] Light
- [X] Did you test your extension when WindowSill is in various location and size?
    - [X] Left / Right of the screen
        - [X] Large size
        - [X] Medium size
        - [X] Small size
    - [X] Bottom / Top of the screen
        - [X] Large size
        - [X] Medium size
        - [X] Small size

### Screenshots

<img width="462" height="268" alt="image" src="https://github.com/user-attachments/assets/b9a65b9f-1867-4362-8edc-2d3d19912329" />

<img width="584" height="588" alt="image" src="https://github.com/user-attachments/assets/d2b79049-a344-47d3-b1db-37cea6cff318" />

<img width="546" height="583" alt="image" src="https://github.com/user-attachments/assets/082b2495-ac97-463f-b253-b593bdffb394" />

<img width="549" height="588" alt="image" src="https://github.com/user-attachments/assets/a9c26386-e4f4-4adf-ae06-f8083b2d39d6" />


